### PR TITLE
Feat/archive

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -21,6 +21,8 @@ export function migrate() {
   let changed = false;
   for (const card of state.cards) {
     if (!valid.has(card.col)) { card.col = state.columns[0].id; changed = true; }
+    if (card.archived === undefined) { card.archived = false; changed = true; }
+    if (card.completedAt === undefined) { card.completedAt = null; changed = true; }
   }
   if (changed) saveCards(state.cards);
 }

--- a/src/features/cards.js
+++ b/src/features/cards.js
@@ -7,6 +7,8 @@ export function addCard({ title, desc, col }) {
     title: (title ?? "").trim(),
     desc:  (desc ?? "").trim(),
     col: col ?? state.columns[0]?.id ?? "todo",
+    archived: false,
+    completedAt: null,
     created: Date.now(),
     updated: Date.now()
   };
@@ -24,4 +26,26 @@ export function deleteCard(id) {
 export function moveCard(id, colId) {
   const c = state.cards.find(x=>x.id===id); if (!c) return;
   if (c.col !== colId) { c.col = colId; c.updated = Date.now(); saveCards(state.cards); }
+}
+
+// Markiert eine Karte als abgeschlossen und archiviert sie
+export function archiveCard(id) {
+  const c = state.cards.find(x=>x.id===id); if (!c) return;
+  if (!c.archived) {
+    c.archived = true;
+    c.completedAt = Date.now();
+    c.updated = Date.now();
+    saveCards(state.cards);
+  }
+}
+
+// Macht die Archivierung rückgängig
+export function unarchiveCard(id) {
+  const c = state.cards.find(x=>x.id===id); if (!c) return;
+  if (c.archived) {
+    c.archived = false;
+    c.completedAt = null;
+    c.updated = Date.now();
+    saveCards(state.cards);
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,49 @@
 import { init, renderBoard } from "./ui/render.js";
+import { renderArchive } from "./ui/archive.js";
 import * as cols from "./features/columns.js";
 import * as cards from "./features/cards.js";
 import { state } from "./core/state.js";
 
 init();
+
+// Header: Archiv-Button einfuegen und View toggeln
+const controlsEl = document.querySelector('.controls.toolbar');
+let archiveBtn = document.getElementById('archiveBtn');
+if (!archiveBtn) {
+  archiveBtn = document.createElement('button');
+  archiveBtn.id = 'archiveBtn';
+  archiveBtn.className = 'ghost';
+  archiveBtn.textContent = 'Archiv';
+  const resetBtn = document.getElementById('resetBtn');
+  if (controlsEl) {
+    if (resetBtn && resetBtn.parentElement === controlsEl) {
+      controlsEl.insertBefore(archiveBtn, resetBtn);
+    } else {
+      controlsEl.appendChild(archiveBtn);
+    }
+  }
+}
+
+let showingArchive = false;
+function updateHeaderButtons() {
+  if (archiveBtn) archiveBtn.textContent = showingArchive ? 'Board' : 'Archiv';
+  const addTask = document.getElementById('addTaskBtn');
+  const addCol = document.getElementById('addColBtn');
+  if (addTask) addTask.style.display = showingArchive ? 'none' : '';
+  if (addCol) addCol.style.display = showingArchive ? 'none' : '';
+}
+
+archiveBtn?.addEventListener('click', () => {
+  showingArchive = !showingArchive;
+  if (showingArchive) {
+    renderArchive();
+  } else {
+    renderBoard();
+  }
+  updateHeaderButtons();
+});
+
+updateHeaderButtons();
 
 // Enter speichert die Karte, wenn der Dialog offen ist (Fokus im Titel)
 const titleInputEl = document.getElementById("titleInput");

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -1,0 +1,124 @@
+import { state } from "../core/state.js";
+import * as cards from "../features/cards.js";
+
+const board = document.getElementById("board");
+const cardTpl = document.getElementById("card-template");
+
+// Renders a simple archive view: one list, newest completed first
+export function renderArchive() {
+  if (!board || !cardTpl) return;
+  board.innerHTML = "";
+
+  const section = document.createElement("section");
+  section.className = "column";
+
+  const header = document.createElement("div");
+  header.className = "column-header";
+  const title = document.createElement("h2");
+  title.textContent = "Archiv";
+  const tools = document.createElement("div");
+  tools.className = "column-tools";
+  header.appendChild(title);
+  header.appendChild(tools);
+
+  const countEl = document.createElement("span");
+  countEl.className = "count small";
+
+  const dropzone = document.createElement("div");
+  dropzone.className = "dropzone";
+
+  section.appendChild(header);
+  section.appendChild(countEl);
+  section.appendChild(dropzone);
+
+  // collect archived cards and sort by completedAt desc
+  const archived = state.cards
+    .filter(c => c.archived === true)
+    .sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0));
+
+  countEl.textContent = `${archived.length} archivierte Karte(n)`;
+
+  for (const c of archived) {
+    const el = cardTpl.content.firstElementChild.cloneNode(true);
+    el.dataset.id = c.id;
+    // disable drag in archive view
+    el.setAttribute("draggable", "false");
+    el.draggable = false;
+
+    el.querySelector(".card-title").textContent = c.title || "(ohne Titel)";
+    el.querySelector(".card-desc").textContent = c.desc || "";
+    // Show completion timestamp under description
+    const ts = c.completedAt ?? c.updated ?? c.created;
+    if (ts) {
+      const meta = document.createElement('div');
+      meta.className = 'small';
+      try {
+        meta.textContent = `Abgeschlossen: ${new Date(ts).toLocaleString('de-DE')}`;
+      } catch {
+        meta.textContent = `Abgeschlossen: ${new Date(ts).toString()}`;
+      }
+      // Insert before actions
+      const actions = el.querySelector('.card-actions');
+      if (actions && actions.parentElement) {
+        actions.parentElement.insertBefore(meta, actions);
+      } else {
+        el.appendChild(meta);
+      }
+    }
+
+    // Actions: Keep delete/edit behavior identical for now
+    el.querySelector('[data-delete]')?.addEventListener('click', () => {
+      if (!confirm('Diese Karte wirklich löschen?')) return;
+      cards.deleteCard(c.id);
+      renderArchive();
+    });
+    el.querySelector('[data-edit]')?.addEventListener('click', () => {
+      const dlg = document.getElementById('taskDialog');
+      const titleInput = document.getElementById('titleInput');
+      const descInput = document.getElementById('descInput');
+      const saveBtn = document.getElementById('saveTaskBtn');
+      const dialogTitle = document.getElementById('dialogTitle');
+
+      if (dialogTitle) dialogTitle.textContent = 'Karte bearbeiten';
+      if (titleInput) titleInput.value = c.title || '';
+      if (descInput) descInput.value = c.desc || '';
+      if (saveBtn) saveBtn.value = 'save';
+
+      const onClose = () => {
+        if (dlg && dlg.returnValue === 'save' && titleInput && titleInput.value.trim()) {
+          cards.updateCard(c.id, { title: titleInput.value, desc: descInput.value });
+          renderArchive();
+        }
+        dlg.removeEventListener('close', onClose);
+      };
+
+      if (dlg && typeof dlg.showModal === 'function') {
+        dlg.addEventListener('close', onClose);
+        dlg.showModal();
+      } else {
+        const nextTitle = prompt('Neuer Titel:', c.title || '');
+        if (nextTitle == null || !nextTitle.trim()) return;
+        const nextDesc = prompt('Neue Beschreibung:', c.desc || '');
+        cards.updateCard(c.id, { title: nextTitle, desc: nextDesc ?? '' });
+        renderArchive();
+      }
+    });
+
+    // Add reactivation button
+    const actions = el.querySelector('.card-actions');
+    if (actions) {
+      const reactivateBtn = document.createElement('button');
+      reactivateBtn.className = 'secondary small';
+      reactivateBtn.textContent = 'Reaktivieren';
+      reactivateBtn.addEventListener('click', () => {
+        cards.unarchiveCard(c.id);
+        renderArchive();
+      });
+      actions.prepend(reactivateBtn);
+    }
+
+    dropzone.appendChild(el);
+  }
+
+  board.appendChild(section);
+}

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -8,7 +8,7 @@ const cardTpl = document.getElementById("card-template");
 
 export function init() {
   migrate();
-  // Event Delegation: Spalten-Löschen-Button
+  // Event Delegation: Spalten loeschen Button
   board.addEventListener('click', (e) => {
     const btn = e.target && e.target.closest ? e.target.closest('[data-del]') : null;
     if (btn) {
@@ -20,7 +20,7 @@ export function init() {
       return;
     }
   });
-  // Event Delegation: Spalten-Umbenennen-Button
+  // Event Delegation: Spalten umbenennen Button
   board.addEventListener('click', (e) => {
     const btn = e.target && e.target.closest ? e.target.closest('[data-rename]') : null;
     if (btn) {
@@ -42,7 +42,7 @@ export function renderBoard() {
     node.dataset.col = col.id;
     node.querySelector("h2").textContent = col.name;
 
-    // Column Drag & Drop (Reihenfolge ändern)
+    // Column Drag & Drop (Reihenfolge aendern)
     const section = node; // <section class="column">
     const header = node.querySelector('[data-col-header]');
     if (header) {
@@ -83,19 +83,19 @@ export function renderBoard() {
       });
     }
 
-    // Dropzone-Events für Karten (Drag & Drop)
-    const dropzone = node.querySelector("[data-dropzone]");
+    // Dropzone-Events fuer Karten (Drag & Drop)
+    const dropzone = node.querySelector('[data-dropzone]');
     if (dropzone) {
-      dropzone.addEventListener("dragover", (e) => {
+      dropzone.addEventListener('dragover', (e) => {
         e.preventDefault();
-        dropzone.classList.add("dragover");
+        dropzone.classList.add('dragover');
       });
-      dropzone.addEventListener("dragleave", () => {
-        dropzone.classList.remove("dragover");
+      dropzone.addEventListener('dragleave', () => {
+        dropzone.classList.remove('dragover');
       });
-      dropzone.addEventListener("drop", (e) => {
+      dropzone.addEventListener('drop', (e) => {
         e.preventDefault();
-        dropzone.classList.remove("dragover");
+        dropzone.classList.remove('dragover');
         const id = state.draggedCardId;
         if (!id) return;
         cards.moveCard(id, col.id);
@@ -103,26 +103,27 @@ export function renderBoard() {
       });
     }
 
-    // … Events anbinden (Rename/Delete/Drag/Drop) und Dropzone-Karten setzen
+    // Append section
     board.appendChild(node);
   }
   renderCards();
 }
 
 export function renderCards() {
-  for (const dz of board.querySelectorAll("[data-dropzone]")) dz.innerHTML = "";
+  for (const dz of board.querySelectorAll('[data-dropzone]')) dz.innerHTML = '';
   for (const c of state.cards) {
+    if (c.archived) continue; // hide archived on board view
     const el = cardTpl.content.firstElementChild.cloneNode(true);
     el.dataset.id = c.id;
-    el.querySelector(".card-title").textContent = c.title || "(ohne Titel)";
-    el.querySelector(".card-desc").textContent = c.desc || "";
-    // … Events anbinden (Edit/Delete/Drag)
+    el.querySelector('.card-title').textContent = c.title || '(ohne Titel)';
+    el.querySelector('.card-desc').textContent = c.desc || '';
+    // Delete
     el.querySelector('[data-delete]')?.addEventListener('click', () => {
-      if (!confirm('Diese Karte wirklich löschen?')) return;
+      if (!confirm('Diese Karte wirklich loeschen?')) return;
       cards.deleteCard(c.id);
       renderCards();
     });
-    // Edit-Event anbinden
+    // Edit
     el.querySelector('[data-edit]')?.addEventListener('click', () => {
       const dlg = document.getElementById('taskDialog');
       const titleInput = document.getElementById('titleInput');
@@ -154,7 +155,19 @@ export function renderCards() {
         renderCards();
       }
     });
-    // Drag-Events binden
+    // Additional action: mark as done -> archive
+    const actions = el.querySelector('.card-actions');
+    if (actions) {
+      const doneBtn = document.createElement('button');
+      doneBtn.className = 'secondary small';
+      doneBtn.textContent = 'Abschliessen';
+      doneBtn.addEventListener('click', () => {
+        cards.archiveCard(c.id);
+        renderCards();
+      });
+      actions.prepend(doneBtn);
+    }
+    // Drag events
     el.addEventListener('dragstart', (e) => {
       state.draggedCardId = c.id;
       if (e.dataTransfer) {
@@ -179,17 +192,17 @@ function clearColDropHints() {
 function handleColumnDelete(colId) {
   const col = state.columns.find(c => c.id === colId);
   if (!col) return;
-  if (state.columns.length <= 1) { alert('Die letzte Spalte kann nicht gelöscht werden.'); return; }
+  if (state.columns.length <= 1) { alert('Die letzte Spalte kann nicht geloescht werden.'); return; }
   const count = state.cards.filter(c => c.col === colId).length;
   if (count === 0) {
-    if (!confirm(`Spalte "${col.name}" wirklich löschen?`)) return;
+    if (!confirm(`Spalte "${col.name}" wirklich loeschen?`)) return;
     cols.deleteColumn(colId, { type: 'delete' });
     renderBoard();
     return;
   }
   const action = prompt(
-    `Spalte "${col.name}" enthält ${count} Karte(n).\n` +
-    `Tippe:\n- "verschieben" um Karten in eine andere Spalte zu verschieben\n- "loeschen" um alle Karten dieser Spalte zu löschen`,
+    `Spalte "${col.name}" enthaelt ${count} Karte(n).\n` +
+    `Tippe:\n- "verschieben" um Karten in eine andere Spalte zu verschieben\n- "loeschen" um alle Karten dieser Spalte zu loeschen`,
     'verschieben'
   );
   if (action == null) return;
@@ -198,14 +211,14 @@ function handleColumnDelete(colId) {
     const targets = state.columns.filter(c => c.id !== colId);
     if (targets.length === 0) { alert('Keine Zielspalte vorhanden.'); return; }
     const list = targets.map((c,i)=>`${i+1}) ${c.name}`).join('\n');
-    const pick = prompt(`Wohin verschieben? Wähle Nummer:\n${list}`, '1');
+    const pick = prompt(`Wohin verschieben? Waehl Nummer:\n${list}`, '1');
     const idx = Number(pick) - 1;
     const target = targets[idx];
     if (!target) return;
     cols.deleteColumn(colId, { type: 'move', to: target.id });
     renderBoard();
   } else if (a.startsWith('loesch') || a.startsWith('loes')) {
-    if (!confirm(`Wirklich Spalte "${col.name}" und alle ${count} Karten löschen?`)) return;
+    if (!confirm(`Wirklich Spalte "${col.name}" und alle ${count} Karten loeschen?`)) return;
     cols.deleteColumn(colId, { type: 'delete' });
     renderBoard();
   }
@@ -221,3 +234,4 @@ function handleColumnRename(colId) {
   cols.renameColumn(colId, name);
   renderBoard();
 }
+


### PR DESCRIPTION
Added an Archive view for completed cards, persisted via new archived and completedAt fields and displayed newest-first without columns. The board hides archived cards, adds a header Archive toggle and per-card Complete/Reactivate actions, and the archive shows a localized completion timestamp.